### PR TITLE
Removed linter checks from test (line 6) &...

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "description": "LambdaSchool Node.js and Express",
   "scripts": {
-    "test": "eslint tests/*.js && eslint src/*.js && mocha -R nyan tests",
-    "test:watch": "npm test -- --watch"
+    "test": "mocha -R nyan tests",
+    "watch": "npm test -- --watch"
   },
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
I changed line 7 so you can run the test with this command: `npm run watch` (for some reason, I and others had trouble running the tests per the instructions.)

I would suggest you use the linter at some point. To do so, just add back this to line 6: `eslint tests/*.js && eslint src/*.js && ` so that the entire line reads:

`    "test": "eslint tests/*.js && eslint src/*.js && mocha -R nyan tests",`

😄 